### PR TITLE
Consistently use the qcow2 image format

### DIFF
--- a/v7/Makefile
+++ b/v7/Makefile
@@ -159,7 +159,7 @@ $(OUTPUT)/index: $(OUTPUT)/$(VERSION).xz
 	echo 'arch=x86_64' >> $(OUTPUT)/index
 	echo 'file='`python -c "import os.path; print(os.path.relpath('$(OUTPUT)/$(VERSION).xz', '.'))"` >> $(OUTPUT)/index
 	echo 'checksum[sha512]='`sha512sum $(OUTPUT)/$(VERSION).xz | awk '{print $$1}'` >> $(OUTPUT)/index
-	echo 'format=raw' >> $(OUTPUT)/index
+	echo 'format=qcow2' >> $(OUTPUT)/index
 	echo '# hardcoded to 6GiB' >> $(OUTPUT)/index
 	echo 'size=6442450944' >> $(OUTPUT)/index
 	echo 'compressed_size='`stat -c %s $(OUTPUT)/$(VERSION).xz` >> $(OUTPUT)/index

--- a/v7/scripts/virt-install.sh
+++ b/v7/scripts/virt-install.sh
@@ -104,7 +104,7 @@ sudo virt-install \
 	--os-type=linux --os-variant=rhel$major \
 	--initrd-inject=$ks \
 	--extra-args="ks=file:/`basename $ks` console=tty0 console=ttyS0,115200" \
-	--disk "$fulloutput,size=6" \
+	--disk "$fulloutput,size=6,format=qcow2" \
 	--serial pty \
 	--location="$iso" \
 	--nographics \


### PR DESCRIPTION
Formerly, the scripts assuming raw images in some places, qcow2 images in other
places. This change explicitly makes all scripts everywhere use the qcow2
format rather than raw and unbreaks the invocation of virt-builder.

On irc we discussed setting the default format to raw, but considering the
resulting image format is qcow2 anyway, and qcow2 is referenced in many more
places in the script than raw, I chose to make vagrant-builder consistently use
qcow2 instead of consistently use raw.

Should resolve #19 
